### PR TITLE
Track current database in Clickhouse queries

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -322,6 +322,8 @@ connstring_parse(const char *connstring)
 			details->username = pstrdup(pval);
 		} else if (strcmp(pname, "password") == 0) {
 			details->password = pstrdup(pval);
+		} else if (strcmp(pname, "dbname") == 0) {
+			details->dbname = pstrdup(pval);
 		}
 	}
 

--- a/src/http.c
+++ b/src/http.c
@@ -50,7 +50,7 @@ size_t write_data(void *contents, size_t size, size_t nmemb, void *userp)
 	return realsize;
 }
 
-ch_http_connection_t *ch_http_connection(char *host, int port, char *username, char *password)
+ch_http_connection_t *ch_http_connection(char *host, int port, char *username, char *password, char *database)
 {
 	int n;
 	char *connstring = NULL;
@@ -100,6 +100,7 @@ ch_http_connection_t *ch_http_connection(char *host, int port, char *username, c
 
 	conn->base_url = connstring;
 	conn->base_url_len = strlen(conn->base_url);
+	conn->database = database;
 
 	return conn;
 
@@ -137,8 +138,10 @@ ch_http_response_t *ch_http_simple_query(ch_http_connection_t *conn, const char 
 	assert(conn && conn->curl);
 
 	/* construct url */
-	url = malloc(conn->base_url_len + 37 + 12 /* query_id + ?query_id= */);
-	sprintf(url, "%s?query_id=%s", conn->base_url, resp->query_id);
+	int database_string_size = 10 + strlen(conn->database);
+	int query_id_string_size =  37 + 12; /* query_id + ?query_id= */
+	url = malloc(conn->base_url_len + query_id_string_size + database_string_size);
+	sprintf(url, "%s?query_id=%s&database=%s", conn->base_url, resp->query_id, conn->database);
 
 	/* constant */
 	errbuffer[0] = '\0';

--- a/src/include/clickhouse_http.h
+++ b/src/include/clickhouse_http.h
@@ -42,7 +42,7 @@ typedef struct {
 
 void ch_http_init(int verbose, uint32_t query_id_prefix);
 void ch_http_set_progress_func(void *progressfunc);
-ch_http_connection_t *ch_http_connection(char *, int, char *, char *);
+ch_http_connection_t *ch_http_connection(char *, int, char *, char *, char *);
 void ch_http_close(ch_http_connection_t *conn);
 ch_http_response_t *ch_http_simple_query(ch_http_connection_t *conn, const char *query);
 char *ch_http_last_error(void);

--- a/src/include/clickhouse_internal.h
+++ b/src/include/clickhouse_internal.h
@@ -8,6 +8,7 @@ typedef struct ch_http_connection_t
 	CURL			   *curl;
 	char			   *base_url;
 	size_t				base_url_len;
+	char				*database;
 } ch_http_connection_t;
 
 typedef struct ch_binary_connection_t

--- a/src/pglink.c
+++ b/src/pglink.c
@@ -85,7 +85,7 @@ chfdw_http_connect(ch_connection_details *details)
 {
 	ch_connection res;
 	ch_http_connection_t *conn = ch_http_connection(details->host, details->port,
-            details->username, details->password);
+            details->username, details->password, details->dbname);
 	if (!initialized)
 	{
 		initialized = true;


### PR DESCRIPTION
The clickhouse_fdw connector is not adding the current_database in the HTTP request. We need that particular field for internal tracking operations.

I have added it as a URL parameter as it was the most straightforward way to configure it. I have considered adding that info from the headers as well using the HTTP header available in the [HTTP interface](https://clickhouse.com/docs/en/interfaces/http/#default-database), but that would require touching the headers from Curl and I didn't want to go that further for this kind of change.

I'm not sure if there is a better way to manage it, so feel free to offer any suggestions.

Thanks!